### PR TITLE
Add provided artifacts in classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.aodocs.endpoints</groupId>
   <artifactId>endpoints-framework-maven-plugin</artifactId>
   <!--Version must be in sync with the endpoints framework version-->
-  <version>2.4.2</version>
+  <version>2.4.3</version>
   <packaging>maven-plugin</packaging>
 
   <name>Endpoints Framework Maven Plugin</name>

--- a/src/main/java/com/google/cloud/tools/maven/endpoints/framework/AbstractEndpointsWebAppMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/endpoints/framework/AbstractEndpointsWebAppMojo.java
@@ -82,7 +82,7 @@ public abstract class AbstractEndpointsWebAppMojo extends AbstractMojo {
 
   private List<String> createParameterList(String actionName)
       throws DependencyResolutionRequiredException {
-    String classpath = Joiner.on(File.pathSeparator).join(project.getRuntimeClasspathElements());
+    String classpath = Joiner.on(File.pathSeparator).join(project.getCompileClasspathElements());
     classpath += File.pathSeparator + classesDir;
     List<String> params =
         new ArrayList<>(


### PR DESCRIPTION
- adds 'provided' artifacts in the classpath of the endpoints
  tool. That way, when endpoints are in an external artifact,
  the endpoints artifact(s) are not added in direct dependencies
  (useful when building client code in a separate artifact)